### PR TITLE
Replace Odin link by real link

### DIFF
--- a/lessons/0_preparation.md
+++ b/lessons/0_preparation.md
@@ -1,7 +1,7 @@
 1. Play with Ruby online: http://tryruby.org/
 2. Installation guides (pick one from below):
     - https://www.ruby-lang.org/en/documentation/installation/
-    - https://www.theodinproject.com/courses/web-development-101/lessons/installations
+    - http://installfest.railsbridge.org/installfest/
     - http://guides.railsgirls.com/install
 3. Interactive ruby console (`irb`): https://www.ruby-lang.org/en/documentation/quickstart/
 


### PR DESCRIPTION
The Odin Project page takes you to the Installfest one. Why not linking directly to that one?